### PR TITLE
Add a formatter option 'auto_open'

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ end
 ## Usage
 
 Just use it as a formatter for [benchee](github.com/PragTob/benchee) and tell it through `html: [file: "your_file.html"]` where the html report should be written to.
+By default, the default browser is opened for viewing reports. You can override this behaviour by passing `html: [file: "your_file.html", auto_open: false]` as a formatting option.
 
 ```elixir
 list = Enum.to_list(1..10_000)

--- a/lib/benchee/formatters/html.ex
+++ b/lib/benchee/formatters/html.ex
@@ -90,14 +90,18 @@ defmodule Benchee.Formatters.HTML do
   end
 
   @default_filename "benchmark_output/my.html"
+  @default_auto_open true
   def output(suite) do
     suite
-    |> update_filename()
+    |> fallback_default_config()
     |> output()
   end
 
-  defp update_filename(suite) do
-    updated_configuration = %Configuration{suite.configuration | formatter_options: %{html: %{file: @default_filename}}}
+  defp fallback_default_config(suite) do
+    opts = Map.get(suite.configuration.formatter_options, :html, %{})
+           |> Map.put_new(:file, @default_filename)
+           |> Map.put_new(:auto_open, @default_auto_open) 
+    updated_configuration = %Configuration{suite.configuration | formatter_options: %{html: opts}}
     %Suite{suite | configuration: updated_configuration}
   end
 

--- a/lib/benchee/formatters/html.ex
+++ b/lib/benchee/formatters/html.ex
@@ -80,12 +80,13 @@ defmodule Benchee.Formatters.HTML do
     particular job (one per benchmark input)
   """
   @spec output(Suite.t) :: Suite.t
-  def output(suite = %{configuration: %{formatter_options: %{html: %{file: _}}}}) do
+  def output(suite = %{configuration: %{formatter_options: %{html: %{file: _, auto_open: auto_open?}}}}) do
     suite
     |> format
     |> write
 
-    open_report(suite)
+    if auto_open?, do: open_report(suite)
+    suite
   end
 
   @default_filename "benchmark_output/my.html"
@@ -250,8 +251,6 @@ defmodule Benchee.Formatters.HTML do
     browser = get_browser()
     {_, exit_code} = System.cmd(browser, [suite.configuration.formatter_options.html.file])
     unless exit_code > 0, do: IO.puts "Opened report using #{browser}"
-
-    suite
   end
 
   defp get_browser do

--- a/lib/benchee/formatters/html.ex
+++ b/lib/benchee/formatters/html.ex
@@ -98,7 +98,8 @@ defmodule Benchee.Formatters.HTML do
   end
 
   defp fallback_default_config(suite) do
-    opts = Map.get(suite.configuration.formatter_options, :html, %{})
+    opts = suite.configuration.formatter_options
+           |> Map.get(:html, %{})
            |> Map.put_new(:file, @default_filename)
            |> Map.put_new(:auto_open, @default_auto_open) 
     updated_configuration = %Configuration{suite.configuration | formatter_options: %{html: opts}}

--- a/test/benchee/formatters/html_integration_test.exs
+++ b/test/benchee/formatters/html_integration_test.exs
@@ -8,7 +8,9 @@ defmodule Benchee.Formatters.HTMLIntegrationTest do
 
   @default_test_directory "benchmark_output"
   @default_file_path "#{@default_test_directory}/my.html"
+  @default_auto_open true
   @default_comparison_path "#{@default_test_directory}/my_comparison.html"
+  @expected_open_report_output ~r/Opened report using (open|xdg-open|explorer)/
 
   test "works just fine" do
     benchee_options = [time: 0.01, 
@@ -43,14 +45,14 @@ defmodule Benchee.Formatters.HTMLIntegrationTest do
 
     assertion_data = %{comparison_path: @default_comparison_path, 
                       test_directory: @default_test_directory, 
-                      file_path: @default_file_path}
+                      file_path: @default_file_path, auto_open: @default_auto_open}
 
     basic_test(benchee_options, assertion_data)
   end
 
   defp basic_test(benchee_options, assertion_data) do
     try do
-      capture_io fn ->
+      out = capture_io fn ->
         Benchee.run %{
           "Sleep"        => fn -> :timer.sleep(10) end,
           "Sleep longer" => fn -> :timer.sleep(20) end
@@ -67,6 +69,7 @@ defmodule Benchee.Formatters.HTMLIntegrationTest do
         assert html =~ "Sleep longer"
         assert html =~ "ips-comparison"
       end
+      if assertion_data.auto_open, do: assert out =~ @expected_open_report_output
     after
       if File.exists?(assertion_data.test_directory), do: File.rm_rf! assertion_data.test_directory
     end

--- a/test/benchee/formatters/html_integration_test.exs
+++ b/test/benchee/formatters/html_integration_test.exs
@@ -14,11 +14,11 @@ defmodule Benchee.Formatters.HTMLIntegrationTest do
     benchee_options = [time: 0.01, 
                       warmup: 0.02, 
                       formatters: [&Benchee.Formatters.HTML.output/1], 
-                      formatter_options: [html: [file: @file_path]]]
+                      formatter_options: [html: [file: @file_path, auto_open: false]]]
 
     assertion_data = %{comparison_path: @comparison_path, 
                       test_directory: @test_directory, 
-                      file_path: @file_path}
+                      file_path: @file_path, auto_open: false}
 
     basic_test(benchee_options, assertion_data)
   end
@@ -27,11 +27,11 @@ defmodule Benchee.Formatters.HTMLIntegrationTest do
     benchee_options = [time: 0.01, 
                       warmup: 0.02, 
                       formatters: [&Benchee.Formatters.HTML.output/1], 
-                      html: [file: @file_path]]
+                      html: [file: @file_path, auto_open: false]]
 
     assertion_data = %{comparison_path: @comparison_path, 
                       test_directory: @test_directory, 
-                      file_path: @file_path}
+                      file_path: @file_path, auto_open: false}
 
     basic_test(benchee_options, assertion_data)
   end

--- a/test/benchee/formatters/html_test.exs
+++ b/test/benchee/formatters/html_test.exs
@@ -28,7 +28,7 @@ defmodule Benchee.Formatters.HTMLTest do
                    scenarios: [@scenario],
                    system: %{elixir: "1.4.0", erlang: "19.1"},
                    configuration: %Benchee.Configuration{
-                     formatter_options: %{html: %{file: @filename}}
+                     formatter_options: %{html: %{file: @filename, auto_open: false}}
                    }
                  }
   @expected_open_report_output ~r/Opened report using (open|xdg-open|explorer)/
@@ -136,7 +136,7 @@ defmodule Benchee.Formatters.HTMLTest do
                ],
                system: %{elixir: "1.4.0", erlang: "19.1"},
                configuration: %Benchee.Configuration{
-                 formatter_options: %{html: %{file: @filename}}
+                 formatter_options: %{html: %{file: @filename, auto_open: false}}
                }
              }
 

--- a/test/benchee/formatters/html_test.exs
+++ b/test/benchee/formatters/html_test.exs
@@ -155,10 +155,12 @@ defmodule Benchee.Formatters.HTMLTest do
   end
 
   test ".output returns the suite again unchanged, produces files and opens them in the default browser" do
+    custom_config = update_in(@sample_suite.configuration |> Map.from_struct(), [:formatter_options, :html, :auto_open], &(&1 || true))
+    custom_suite = %Benchee.Suite{ @sample_suite | configuration: struct(Benchee.Configuration, custom_config) }
     try do
       output = capture_io fn ->
-        return = Benchee.Formatters.HTML.output(@sample_suite)
-        assert return == @sample_suite
+        return = Benchee.Formatters.HTML.output(custom_suite)
+        assert return == custom_suite
       end
 
       assert File.exists? @expected_filename


### PR DESCRIPTION
Hello,
This PR closes #27 by adding a formatter option `auto_open` to control whether a report should be opened in a browser window automatically or not. The default value is set to `true` to maintain compatibility with the current behavior, but it's overriden to `false` for most tests.