### PR TITLE
Add a formatter option 'auto_open' Continued

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,6 @@ erl_crash.dump
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
 my.html
-samples_output
+/samples_output
+/output
+/benchmarks/output

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ end
 
 ## Usage
 
-Just use it as a formatter for [benchee](github.com/PragTob/benchee) and tell it through `html: [file: "your_file.html"]` where the html report should be written to.
-By default, the default browser is opened for viewing reports. You can override this behaviour by passing `html: [file: "your_file.html", auto_open: false]` as a formatting option.
+Just use it as a formatter for [benchee](github.com/PragTob/benchee):
 
 ```elixir
 list = Enum.to_list(1..10_000)
@@ -32,12 +31,15 @@ Benchee.run(%{
   "map.flatten" => fn -> list |> Enum.map(map_fun) |> List.flatten end
 },
   formatters: [
-    &Benchee.Formatters.HTML.output/1,
-    &Benchee.Formatters.Console.output/1
-  ],
-  formatter_options: [html: [file: "samples_output/my.html"]],
+    Benchee.Formatters.HTML,
+    Benchee.Formatters.Console
+  ]
+  # override defaults
+  #, formatter_options: [html: [file: "output/my.html", auto_open: false]]
 )
 ```
+
+The report index page will be written to `"benchmarks/output/results.html"` and opened in your standard browser automatically. Of course you can also pass in `formatter_options` to specify a different destination for the reports: `html: [file: "your_file.html"]`. Auto open behaviour can be overridden in the same manner: `html: [auto_open: false]`
 
 Of course it also works with multiple inputs, in that case one file per input is generated:
 
@@ -49,8 +51,8 @@ Benchee.run(%{
   "map.flatten" => fn(list) -> list |> Enum.map(map_fun) |> List.flatten end
 },
   formatters: [
-    &Benchee.Formatters.HTML.output/1,
-    &Benchee.Formatters.Console.output/1
+    Benchee.Formatters.HTML,
+    Benchee.Formatters.Console
   ],
   formatter_options: [html: [file: "samples_output/my.html"]],
   time: 7,

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ end
 ## Usage
 
 Just use it as a formatter for [benchee](github.com/PragTob/benchee) and tell it through `html: [file: "your_file.html"]` where the html report should be written to.
+By default, the default browser is opened for viewing reports. You can override this behaviour by passing `html: [file: "your_file.html", auto_open: false]` as a formatting option.
 
 ```elixir
 list = Enum.to_list(1..10_000)

--- a/lib/benchee/formatters/html.ex
+++ b/lib/benchee/formatters/html.ex
@@ -80,60 +80,70 @@ defmodule Benchee.Formatters.HTML do
     particular job (one per benchmark input)
   """
   @spec output(Suite.t) :: Suite.t
-  def output(suite = %{configuration: %{formatter_options: %{html: %{file: _, auto_open: auto_open?}}}}) do
+  def output(suite) do
     suite
     |> format
     |> write
 
-    if auto_open?, do: open_report(suite)
     suite
-  end
-
-  @default_filename "benchmark_output/my.html"
-  @default_auto_open true
-  def output(suite) do
-    suite
-    |> fallback_default_config()
-    |> output()
-  end
-
-  defp fallback_default_config(suite) do
-    opts = suite.configuration.formatter_options
-           |> Map.get(:html, %{})
-           |> Map.put_new(:file, @default_filename)
-           |> Map.put_new(:auto_open, @default_auto_open) 
-    updated_configuration = %Configuration{suite.configuration | formatter_options: %{html: opts}}
-    %Suite{suite | configuration: updated_configuration}
   end
 
   @doc """
   Transforms the statistical results from benchmarking to html to be written
   somewhere, such as a file through `IO.write/2`.
 
-  Returns a map from file name/path to file content.
+  Returns a map from file name/path to file content along with formatter options.
   """
-  @spec format(Suite.t) :: {%{Suite.key => String.t}, String.t}
-  def format(%Suite{scenarios: scenarios, system: system,
+  @spec format(Suite.t) :: {%{Suite.key => String.t}, map}
+  def format(suite) do
+    suite
+    |> default_configuration
+    |> do_format
+  end
+
+  @default_filename "benchmarks/my.html"
+  @default_auto_open true
+  defp default_configuration(suite) do
+    opts = suite.configuration.formatter_options
+           |> Map.get(:html, %{})
+           |> Map.put_new(:file, @default_filename)
+           |> Map.put_new(:auto_open, @default_auto_open)
+    updated_configuration = %Configuration{suite.configuration | formatter_options: %{html: opts}}
+    %Suite{suite | configuration: updated_configuration}
+  end
+
+  defp do_format(%Suite{scenarios: scenarios, system: system,
                configuration: %{
-                 formatter_options: %{html: %{file: filename}},
+                 formatter_options: %{html: options = %{file: filename}},
                  unit_scaling: unit_scaling
                }}) do
     data = scenarios
            |> Enum.group_by(fn(scenario) -> scenario.input_name end)
-           |> Enum.map(fn(tagged_scenarios) -> reports_for_input(tagged_scenarios, system, filename, unit_scaling) end)
+           |> Enum.map(fn(tagged_scenarios) ->
+                reports_for_input(tagged_scenarios, system, filename, unit_scaling)
+              end)
            |> add_index(filename, system)
            |> List.flatten
            |> Map.new
 
-    {data, filename}
+    {data, options}
   end
 
-  @spec write({%{Suite.key => String.t}, String.t}) :: :ok
-  def write({data, filename}) do
-    filename |> create_base_directory |> copy_asset_files
+  @spec write({%{Suite.key => String.t}, map}) :: :ok
+  def write({data, %{file: filename, auto_open: auto_open?}}) do
+    prepare_folder_structure(filename)
 
     FileCreation.each(data, filename)
+
+    if auto_open?, do: open_report(filename)
+
     :ok
+  end
+
+  defp prepare_folder_structure(filename) do
+    filename
+    |> create_base_directory
+    |> copy_asset_files
   end
 
   defp create_base_directory(filename) do
@@ -252,9 +262,9 @@ defmodule Benchee.Formatters.HTML do
   end
   defp max_width_class(_job_count), do: ""
 
-  defp open_report(suite) do
+  defp open_report(filename) do
     browser = get_browser()
-    {_, exit_code} = System.cmd(browser, [suite.configuration.formatter_options.html.file])
+    {_, exit_code} = System.cmd(browser, [filename])
     unless exit_code > 0, do: IO.puts "Opened report using #{browser}"
   end
 

--- a/lib/benchee/formatters/html.ex
+++ b/lib/benchee/formatters/html.ex
@@ -101,7 +101,7 @@ defmodule Benchee.Formatters.HTML do
     |> do_format
   end
 
-  @default_filename "benchmarks/my.html"
+  @default_filename "benchmarks/output/results.html"
   @default_auto_open true
   defp default_configuration(suite) do
     opts = suite.configuration.formatter_options

--- a/samples/many_jobs.exs
+++ b/samples/many_jobs.exs
@@ -16,7 +16,7 @@ Benchee.run %{
    warmup: 0,
    unit_scaling: :largest,
    formatters: [
-     &Benchee.Formatters.Console.output/1,
-     &Benchee.Formatters.HTML.output/1
+     Benchee.Formatters.Console,
+     Benchee.Formatters.HTML
    ],
    formatter_options: [html: [file: "samples_output/many.html"]]

--- a/samples/multiple_inputs.exs
+++ b/samples/multiple_inputs.exs
@@ -5,8 +5,8 @@ Benchee.run(%{
   "map.flatten" => fn(list) -> list |> Enum.map(map_fun) |> List.flatten end
 },
   formatters: [
-    &Benchee.Formatters.HTML.output/1,
-    &Benchee.Formatters.Console.output/1
+    Benchee.Formatters.HTML,
+    Benchee.Formatters.Console
   ],
   formatter_options: [html: [file: "samples_output/my.html"]],
   time: 7,

--- a/samples/run.exs
+++ b/samples/run.exs
@@ -8,8 +8,7 @@ Benchee.run(%{
   "map.flatten" => fn -> list |> Enum.map(map_fun) |> List.flatten end
 },
   formatters: [
-    &Benchee.Formatters.HTML.output/1,
-    &Benchee.Formatters.Console.output/1
-  ],
-  formatter_options: [html: [file: "samples_output/flattening_map.html"]],
+    Benchee.Formatters.HTML,
+    Benchee.Formatters.Console
+  ]
 )

--- a/samples/run_old_school.exs
+++ b/samples/run_old_school.exs
@@ -1,3 +1,5 @@
+# It is possible to use multiple formatters so that you have both the Console
+# output and an HTML file.
 list = Enum.to_list(1..10_000)
 map_fun = fn(i) -> [i, i * i] end
 
@@ -6,10 +8,7 @@ Benchee.run(%{
   "map.flatten" => fn -> list |> Enum.map(map_fun) |> List.flatten end
 },
   formatters: [
-    Benchee.Formatters.HTML,
-    Benchee.Formatters.Console
-  ],
-  formatter_options: [html: [file: "samples_output/my.html"]],
-  time: 2,
-  warmup: 0
+    &Benchee.Formatters.HTML.output/1,
+    &Benchee.Formatters.Console.output/1
+  ]
 )

--- a/samples/run_options.exs
+++ b/samples/run_options.exs
@@ -9,7 +9,5 @@ Benchee.run(%{
     Benchee.Formatters.HTML,
     Benchee.Formatters.Console
   ],
-  formatter_options: [html: [file: "samples_output/my.html"]],
-  time: 2,
-  warmup: 0
+  formatter_options: [html: [file: "output/my.html", auto_open: false]]
 )

--- a/test/benchee/formatters/html_integration_test.exs
+++ b/test/benchee/formatters/html_integration_test.exs
@@ -6,53 +6,65 @@ defmodule Benchee.Formatters.HTMLIntegrationTest do
   @file_path "#{@test_directory}/my.html"
   @comparison_path "#{@test_directory}/my_comparison.html"
 
-  @default_test_directory "benchmark_output"
+  @default_test_directory "benchmarks"
   @default_file_path "#{@default_test_directory}/my.html"
-  @default_auto_open true
   @default_comparison_path "#{@default_test_directory}/my_comparison.html"
-  @expected_open_report_output ~r/Opened report using (open|xdg-open|explorer)/
 
   test "works just fine" do
-    benchee_options = [time: 0.01, 
-                      warmup: 0.02, 
-                      formatters: [&Benchee.Formatters.HTML.output/1], 
+    benchee_options = [time: 0.01,
+                      warmup: 0.02,
+                      formatters: [Benchee.Formatters.HTML],
                       formatter_options: [html: [file: @file_path, auto_open: false]]]
 
-    assertion_data = %{comparison_path: @comparison_path, 
-                      test_directory: @test_directory, 
-                      file_path: @file_path, auto_open: false}
+    assertion_data = %{comparison_path: @comparison_path,
+                      test_directory: @test_directory,
+                      file_path: @file_path}
+
+    basic_test(benchee_options, assertion_data)
+  end
+
+  test "works with the old school function as formatter" do
+    benchee_options = [time: 0.01,
+                      warmup: 0.02,
+                      formatters: [&Benchee.Formatters.HTML.output/1],
+                      formatter_options: [html: [file: @file_path, auto_open: false]]]
+
+    assertion_data = %{comparison_path: @comparison_path,
+                      test_directory: @test_directory,
+                      file_path: @file_path}
 
     basic_test(benchee_options, assertion_data)
   end
 
   test "works fine with the legacy format" do
-    benchee_options = [time: 0.01, 
-                      warmup: 0.02, 
-                      formatters: [&Benchee.Formatters.HTML.output/1], 
+    benchee_options = [time: 0.01,
+                      warmup: 0.02,
+                      formatters: [Benchee.Formatters.HTML],
                       html: [file: @file_path, auto_open: false]]
 
-    assertion_data = %{comparison_path: @comparison_path, 
-                      test_directory: @test_directory, 
-                      file_path: @file_path, auto_open: false}
+    assertion_data = %{comparison_path: @comparison_path,
+                      test_directory: @test_directory,
+                      file_path: @file_path}
 
     basic_test(benchee_options, assertion_data)
   end
 
   test "works fine with filename not provided" do
-    benchee_options = [time: 0.01, 
-                      warmup: 0.02, 
-                      formatters: [&Benchee.Formatters.HTML.output/1]]
+    benchee_options = [time: 0.01,
+                      warmup: 0.02,
+                      formatters: [Benchee.Formatters.HTML],
+                      formatter_options: [html: [auto_open: false]]]
 
-    assertion_data = %{comparison_path: @default_comparison_path, 
-                      test_directory: @default_test_directory, 
-                      file_path: @default_file_path, auto_open: @default_auto_open}
+    assertion_data = %{comparison_path: @default_comparison_path,
+                      test_directory: @default_test_directory,
+                      file_path: @default_file_path}
 
     basic_test(benchee_options, assertion_data)
   end
 
   defp basic_test(benchee_options, assertion_data) do
     try do
-      out = capture_io fn ->
+      capture_io fn ->
         Benchee.run %{
           "Sleep"        => fn -> :timer.sleep(10) end,
           "Sleep longer" => fn -> :timer.sleep(20) end
@@ -69,7 +81,6 @@ defmodule Benchee.Formatters.HTMLIntegrationTest do
         assert html =~ "Sleep longer"
         assert html =~ "ips-comparison"
       end
-      if assertion_data.auto_open, do: assert out =~ @expected_open_report_output
     after
       if File.exists?(assertion_data.test_directory), do: File.rm_rf! assertion_data.test_directory
     end

--- a/test/benchee/formatters/html_integration_test.exs
+++ b/test/benchee/formatters/html_integration_test.exs
@@ -3,12 +3,14 @@ defmodule Benchee.Formatters.HTMLIntegrationTest do
   import ExUnit.CaptureIO
 
   @test_directory "test_output"
-  @file_path "#{@test_directory}/my.html"
-  @comparison_path "#{@test_directory}/my_comparison.html"
+  @base_name "my"
+  @file_path "#{@test_directory}/#{@base_name}.html"
+  @comparison_path "#{@test_directory}/#{@base_name}_comparison.html"
 
-  @default_test_directory "benchmarks"
-  @default_file_path "#{@default_test_directory}/my.html"
-  @default_comparison_path "#{@default_test_directory}/my_comparison.html"
+  @default_test_directory "benchmarks/output"
+  @default_base_name "results"
+  @default_file_path "#{@default_test_directory}/#{@default_base_name}.html"
+  @default_comparison_path "#{@default_test_directory}/#{@default_base_name}_comparison.html"
 
   test "works just fine" do
     benchee_options = [time: 0.01,
@@ -17,8 +19,10 @@ defmodule Benchee.Formatters.HTMLIntegrationTest do
                       formatter_options: [html: [file: @file_path, auto_open: false]]]
 
     assertion_data = %{comparison_path: @comparison_path,
-                      test_directory: @test_directory,
-                      file_path: @file_path}
+                       test_directory: @test_directory,
+                       file_path: @file_path,
+                       base_name: @base_name
+                     }
 
     basic_test(benchee_options, assertion_data)
   end
@@ -30,21 +34,25 @@ defmodule Benchee.Formatters.HTMLIntegrationTest do
                       formatter_options: [html: [file: @file_path, auto_open: false]]]
 
     assertion_data = %{comparison_path: @comparison_path,
-                      test_directory: @test_directory,
-                      file_path: @file_path}
+                       test_directory: @test_directory,
+                       file_path: @file_path,
+                       base_name: @base_name
+                     }
 
     basic_test(benchee_options, assertion_data)
   end
 
-  test "works fine with the legacy format" do
+  test "works fine with the legacy configuration format" do
     benchee_options = [time: 0.01,
                       warmup: 0.02,
                       formatters: [Benchee.Formatters.HTML],
                       html: [file: @file_path, auto_open: false]]
 
     assertion_data = %{comparison_path: @comparison_path,
-                      test_directory: @test_directory,
-                      file_path: @file_path}
+                       test_directory: @test_directory,
+                       file_path: @file_path,
+                       base_name: @base_name
+                     }
 
     basic_test(benchee_options, assertion_data)
   end
@@ -56,8 +64,10 @@ defmodule Benchee.Formatters.HTMLIntegrationTest do
                       formatter_options: [html: [auto_open: false]]]
 
     assertion_data = %{comparison_path: @default_comparison_path,
-                      test_directory: @default_test_directory,
-                      file_path: @default_file_path}
+                       test_directory: @default_test_directory,
+                       file_path: @default_file_path,
+                       base_name: @default_base_name
+                     }
 
     basic_test(benchee_options, assertion_data)
   end
@@ -71,8 +81,8 @@ defmodule Benchee.Formatters.HTMLIntegrationTest do
         }, benchee_options
 
         assert File.exists?(assertion_data.comparison_path)
-        assert File.exists?("#{assertion_data.test_directory}/my_sleep.html")
-        assert File.exists?("#{assertion_data.test_directory}/my_sleep_longer.html")
+        assert File.exists?("#{assertion_data.test_directory}/#{assertion_data.base_name}_sleep.html")
+        assert File.exists?("#{assertion_data.test_directory}/#{assertion_data.base_name}_sleep_longer.html")
         assert File.exists?(assertion_data.file_path)
         html = File.read! assertion_data.comparison_path
 

--- a/test/benchee/formatters/html_integration_test.exs
+++ b/test/benchee/formatters/html_integration_test.exs
@@ -8,17 +8,19 @@ defmodule Benchee.Formatters.HTMLIntegrationTest do
 
   @default_test_directory "benchmark_output"
   @default_file_path "#{@default_test_directory}/my.html"
+  @default_auto_open true
   @default_comparison_path "#{@default_test_directory}/my_comparison.html"
+  @expected_open_report_output ~r/Opened report using (open|xdg-open|explorer)/
 
   test "works just fine" do
     benchee_options = [time: 0.01, 
                       warmup: 0.02, 
                       formatters: [&Benchee.Formatters.HTML.output/1], 
-                      formatter_options: [html: [file: @file_path]]]
+                      formatter_options: [html: [file: @file_path, auto_open: false]]]
 
     assertion_data = %{comparison_path: @comparison_path, 
                       test_directory: @test_directory, 
-                      file_path: @file_path}
+                      file_path: @file_path, auto_open: false}
 
     basic_test(benchee_options, assertion_data)
   end
@@ -27,11 +29,11 @@ defmodule Benchee.Formatters.HTMLIntegrationTest do
     benchee_options = [time: 0.01, 
                       warmup: 0.02, 
                       formatters: [&Benchee.Formatters.HTML.output/1], 
-                      html: [file: @file_path]]
+                      html: [file: @file_path, auto_open: false]]
 
     assertion_data = %{comparison_path: @comparison_path, 
                       test_directory: @test_directory, 
-                      file_path: @file_path}
+                      file_path: @file_path, auto_open: false}
 
     basic_test(benchee_options, assertion_data)
   end
@@ -43,14 +45,14 @@ defmodule Benchee.Formatters.HTMLIntegrationTest do
 
     assertion_data = %{comparison_path: @default_comparison_path, 
                       test_directory: @default_test_directory, 
-                      file_path: @default_file_path}
+                      file_path: @default_file_path, auto_open: @default_auto_open}
 
     basic_test(benchee_options, assertion_data)
   end
 
   defp basic_test(benchee_options, assertion_data) do
     try do
-      capture_io fn ->
+      out = capture_io fn ->
         Benchee.run %{
           "Sleep"        => fn -> :timer.sleep(10) end,
           "Sleep longer" => fn -> :timer.sleep(20) end
@@ -67,6 +69,7 @@ defmodule Benchee.Formatters.HTMLIntegrationTest do
         assert html =~ "Sleep longer"
         assert html =~ "ips-comparison"
       end
+      if assertion_data.auto_open, do: assert out =~ @expected_open_report_output
     after
       if File.exists?(assertion_data.test_directory), do: File.rm_rf! assertion_data.test_directory
     end

--- a/test/benchee/formatters/html_test.exs
+++ b/test/benchee/formatters/html_test.exs
@@ -28,7 +28,7 @@ defmodule Benchee.Formatters.HTMLTest do
                    scenarios: [@scenario],
                    system: %{elixir: "1.4.0", erlang: "19.1"},
                    configuration: %Benchee.Configuration{
-                     formatter_options: %{html: %{file: @filename}}
+                     formatter_options: %{html: %{file: @filename, auto_open: false}}
                    }
                  }
   @expected_open_report_output ~r/Opened report using (open|xdg-open|explorer)/
@@ -136,7 +136,7 @@ defmodule Benchee.Formatters.HTMLTest do
                ],
                system: %{elixir: "1.4.0", erlang: "19.1"},
                configuration: %Benchee.Configuration{
-                 formatter_options: %{html: %{file: @filename}}
+                 formatter_options: %{html: %{file: @filename, auto_open: false}}
                }
              }
 
@@ -155,10 +155,12 @@ defmodule Benchee.Formatters.HTMLTest do
   end
 
   test ".output returns the suite again unchanged, produces files and opens them in the default browser" do
+    custom_config = update_in(@sample_suite.configuration |> Map.from_struct(), [:formatter_options, :html, :auto_open], &(&1 || true))
+    custom_suite = %Benchee.Suite{ @sample_suite | configuration: struct(Benchee.Configuration, custom_config) }
     try do
       output = capture_io fn ->
-        return = Benchee.Formatters.HTML.output(@sample_suite)
-        assert return == @sample_suite
+        return = Benchee.Formatters.HTML.output(custom_suite)
+        assert return == custom_suite
       end
 
       assert File.exists? @expected_filename

--- a/test/benchee/formatters/html_test.exs
+++ b/test/benchee/formatters/html_test.exs
@@ -31,8 +31,6 @@ defmodule Benchee.Formatters.HTMLTest do
                      formatter_options: %{html: %{file: @filename, auto_open: false}}
                    }
                  }
-  @expected_open_report_output ~r/Opened report using (open|xdg-open|explorer)/
-
   test ".format returns an HTML-ish string for every input" do
     {format, _} = HTML.format @sample_suite
 
@@ -154,13 +152,11 @@ defmodule Benchee.Formatters.HTMLTest do
     end
   end
 
-  test ".output returns the suite again unchanged, produces files and opens them in the default browser" do
-    custom_config = update_in(@sample_suite.configuration |> Map.from_struct(), [:formatter_options, :html, :auto_open], &(&1 || true))
-    custom_suite = %Benchee.Suite{ @sample_suite | configuration: struct(Benchee.Configuration, custom_config) }
+  test ".output returns the suite again unchanged, produces files" do
     try do
-      output = capture_io fn ->
-        return = Benchee.Formatters.HTML.output(custom_suite)
-        assert return == custom_suite
+      capture_io fn ->
+        return = Benchee.Formatters.HTML.output(@sample_suite)
+        assert return == @sample_suite
       end
 
       assert File.exists? @expected_filename
@@ -168,8 +164,6 @@ defmodule Benchee.Formatters.HTMLTest do
 
       content = File.read! @expected_filename
       assert_includes content, ["My Job", "average"]
-
-      assert output =~ @expected_open_report_output
     after
       if File.exists?(@test_directory), do: File.rm_rf! @test_directory
     end


### PR DESCRIPTION
Original is #28 with major props to @seleem1337 :tada: :tada: 

* rebased to fixed master to hopefully fix tests + squashed for better overview
* moved bits around so that they also work if only `suite |> format |> write` is called (which should be the most common use case (tm), we need to keep people from doing more stuff in `output`)
* removed all occurences of opening the browser in the tests - while testing it is great, I can absolutely not have things opening the browser during test run :)