### PR TITLE
Show system data

### DIFF
--- a/lib/benchee/formatters/html.ex
+++ b/lib/benchee/formatters/html.ex
@@ -41,11 +41,15 @@ defmodule Benchee.Formatters.HTML do
 
   EEx.function_from_file :defp, :system_info,
                          "priv/templates/partials/system_info.html.eex",
-                         [:system]
+                         [:system, :options]
 
   # Small wrapper to have default arguments
   defp render_data_table(statistics, units, options \\ []) do
     data_table statistics, units, options
+  end
+
+  defp render_system_info(system, options \\ [visible: false]) do
+    system_info(system, options)
   end
 
   @moduledoc """

--- a/lib/benchee/formatters/html.ex
+++ b/lib/benchee/formatters/html.ex
@@ -39,6 +39,10 @@ defmodule Benchee.Formatters.HTML do
                          "priv/templates/partials/data_table.html.eex",
                          [:statistics, :units, :options]
 
+  EEx.function_from_file :defp, :system_info,
+                         "priv/templates/partials/system_info.html.eex",
+                         [:system]
+
   # Small wrapper to have default arguments
   defp render_data_table(statistics, units, options \\ []) do
     data_table statistics, units, options

--- a/lib/benchee/formatters/html.ex
+++ b/lib/benchee/formatters/html.ex
@@ -43,11 +43,10 @@ defmodule Benchee.Formatters.HTML do
                          "priv/templates/partials/system_info.html.eex",
                          [:system, :options]
 
-  # Small wrapper to have default arguments
+  # Small wrappers to have default arguments
   defp render_data_table(statistics, units, options \\ []) do
     data_table statistics, units, options
   end
-
   defp render_system_info(system, options \\ [visible: false]) do
     system_info(system, options)
   end

--- a/lib/benchee/formatters/html.ex
+++ b/lib/benchee/formatters/html.ex
@@ -25,13 +25,13 @@ defmodule Benchee.Formatters.HTML do
                          []
   EEx.function_from_file :defp, :header,
                          "priv/templates/partials/header.html.eex",
-                         [:input_name, :system]
+                         [:input_name]
   EEx.function_from_file :defp, :js_includes,
                          "priv/templates/partials/js_includes.html.eex",
                          []
   EEx.function_from_file :defp, :version_note,
                          "priv/templates/partials/version_note.html.eex",
-                         [:system]
+                         []
   EEx.function_from_file :defp, :input_label,
                          "priv/templates/partials/input_label.html.eex",
                          [:input_name]

--- a/priv/assets/javascripts/benchee.js
+++ b/priv/assets/javascripts/benchee.js
@@ -107,3 +107,10 @@ window.drawRunTimeHistograms = function(runTimes, inputHeadline) {
   };
   drawGraph(runTimeHistogramNode, runtimeHistogramData(runTimes), layout);
 };
+
+window.toggleSystemDataInfo = function() {
+  var systemDataNode = document.getElementById("system-info");
+  var newState = (systemDataNode.style.display === 'block') ? 'none' : 'block';
+  
+  systemDataNode.style.display = newState;
+};

--- a/priv/assets/stylesheets/benchee.css
+++ b/priv/assets/stylesheets/benchee.css
@@ -124,6 +124,10 @@ a:hover {
   text-decoration: none;
 }
 
+.benchee-systeminfo {
+  display: none;
+}
+
 ul.benchee-systeminfo-list {
   columns: 2;
   -webkit-columns: 2;

--- a/priv/assets/stylesheets/benchee.css
+++ b/priv/assets/stylesheets/benchee.css
@@ -124,6 +124,12 @@ a:hover {
   text-decoration: none;
 }
 
+ul.benchee-systeminfo-list {
+  columns: 2;
+  -webkit-columns: 2;
+  -moz-columns: 2;
+}
+
 .benchee-plot-container {
   display: flex;
   justify-content: center;

--- a/priv/templates/comparison.html.eex
+++ b/priv/templates/comparison.html.eex
@@ -5,6 +5,8 @@
 
     <%= header(input_name, suite.system) %>
 
+    <%= system_info(suite.system) %>
+
     <article>
       <h2>
         Comparison

--- a/priv/templates/comparison.html.eex
+++ b/priv/templates/comparison.html.eex
@@ -5,7 +5,7 @@
 
     <%= header(input_name, suite.system) %>
 
-    <%= system_info(suite.system) %>
+    <%= render_system_info(suite.system) %>
 
     <article>
       <h2>

--- a/priv/templates/comparison.html.eex
+++ b/priv/templates/comparison.html.eex
@@ -3,7 +3,7 @@
   <%= head() %>
   <body>
 
-    <%= header(input_name, suite.system) %>
+    <%= header(input_name) %>
 
     <%= render_system_info(suite.system) %>
 

--- a/priv/templates/index.html.eex
+++ b/priv/templates/index.html.eex
@@ -8,7 +8,7 @@
       <%= version_note(system) %>
     </div>
     
-    <%= system_info(system) %>
+    <%= render_system_info(system, visible: true) %>
     
     <article>
       <%= for {input_name, paths} <- names_to_paths do %>
@@ -24,5 +24,7 @@
       <% end %>
 
     </article>
+
+    <%= js_includes() %>
   </body>
 </html>

--- a/priv/templates/index.html.eex
+++ b/priv/templates/index.html.eex
@@ -5,7 +5,7 @@
 
     <div class="header">
       <h1>benchee report index</h1>
-      <%= version_note(system) %>
+      <%= version_note() %>
     </div>
     
     <%= render_system_info(system, visible: true) %>

--- a/priv/templates/index.html.eex
+++ b/priv/templates/index.html.eex
@@ -7,7 +7,9 @@
       <h1>benchee report index</h1>
       <%= version_note(system) %>
     </div>
-
+    
+    <%= system_info(system) %>
+    
     <article>
       <%= for {input_name, paths} <- names_to_paths do %>
         <section>

--- a/priv/templates/job_detail.html.eex
+++ b/priv/templates/job_detail.html.eex
@@ -5,7 +5,7 @@
 
     <%= header(input_name, system) %>
 
-    <%= system_info(system) %>
+    <%= render_system_info(system) %>
     
     <article>
       <h2>

--- a/priv/templates/job_detail.html.eex
+++ b/priv/templates/job_detail.html.eex
@@ -3,7 +3,7 @@
   <%= head() %>
   <body>
 
-    <%= header(input_name, system) %>
+    <%= header(input_name) %>
 
     <%= render_system_info(system) %>
     

--- a/priv/templates/job_detail.html.eex
+++ b/priv/templates/job_detail.html.eex
@@ -5,6 +5,8 @@
 
     <%= header(input_name, system) %>
 
+    <%= system_info(system) %>
+    
     <article>
       <h2>
         <a name="<%= job_name %>"></a>

--- a/priv/templates/partials/header.html.eex
+++ b/priv/templates/partials/header.html.eex
@@ -1,5 +1,5 @@
 <div class="header">
   <h1>benchee report</h1>
   <%= input_label(input_name) %>
-  <%= version_note(system) %>
+  <%= version_note() %>
 </div>

--- a/priv/templates/partials/system_info.html.eex
+++ b/priv/templates/partials/system_info.html.eex
@@ -1,4 +1,4 @@
-<article>
+<article id="system-info" class="benchee-systeminfo" <%= if options[:visible] do %>style="display: block;"<% end %>>
   <h3>System info</h3>
   <ul class="benchee-systeminfo-list">
     <li>Elixir: <%= system.elixir%></li>

--- a/priv/templates/partials/system_info.html.eex
+++ b/priv/templates/partials/system_info.html.eex
@@ -1,0 +1,11 @@
+<article>
+  <h3>System info</h3>
+  <ul class="benchee-systeminfo-list">
+    <li>Elixir: <%= system.elixir%></li>
+    <li>Erlang: <%= system.erlang %></li>
+    <li>Operating system: <%= system.os %></li>
+    <li>Available memory: <%= system.available_memory %></li>
+    <li>CPU Information: <%= system.cpu_speed %></li>
+    <li>Number of Available Cores: <%= system.num_cores %></li>
+  </ul>
+</article>

--- a/priv/templates/partials/version_note.html.eex
+++ b/priv/templates/partials/version_note.html.eex
@@ -1,3 +1,3 @@
 <span class="version-note">
-  <a href="javascript:toggleSystemDataInfo();" title="Click to toggle system info">Elixir <%= system.elixir%>, Erlang <%= system.erlang %></a>
+  <a href="javascript:toggleSystemDataInfo();" title="Click to toggle system info">System info</a>
 </span>

--- a/priv/templates/partials/version_note.html.eex
+++ b/priv/templates/partials/version_note.html.eex
@@ -1,3 +1,3 @@
-<a class="version-note" href="javascript:toggleSystemDataInfo();">
-  Elixir <%= system.elixir%>, Erlang <%= system.erlang %>
-</a>
+<span class="version-note">
+  <a href="javascript:toggleSystemDataInfo();" title="Click to toggle system info">Elixir <%= system.elixir%>, Erlang <%= system.erlang %></a>
+</span>

--- a/priv/templates/partials/version_note.html.eex
+++ b/priv/templates/partials/version_note.html.eex
@@ -1,3 +1,3 @@
-<span class="version-note">
+<a class="version-note" href="javascript:toggleSystemDataInfo();">
   Elixir <%= system.elixir%>, Erlang <%= system.erlang %>
-</span>
+</a>

--- a/test/benchee/formatters/html_integration_test.exs
+++ b/test/benchee/formatters/html_integration_test.exs
@@ -66,6 +66,7 @@ defmodule Benchee.Formatters.HTMLIntegrationTest do
         assert html =~ "Sleep"
         assert html =~ "Sleep longer"
         assert html =~ "ips-comparison"
+        assert html =~ "<h3>System info</h3>"
       end
     after
       if File.exists?(assertion_data.test_directory), do: File.rm_rf! assertion_data.test_directory

--- a/test/benchee/formatters/html_integration_test.exs
+++ b/test/benchee/formatters/html_integration_test.exs
@@ -66,7 +66,7 @@ defmodule Benchee.Formatters.HTMLIntegrationTest do
         assert html =~ "Sleep"
         assert html =~ "Sleep longer"
         assert html =~ "ips-comparison"
-        assert html =~ "<h3>System info</h3>"
+        assert html =~ "System info</a>"
       end
     after
       if File.exists?(assertion_data.test_directory), do: File.rm_rf! assertion_data.test_directory

--- a/test/benchee/formatters/html_test.exs
+++ b/test/benchee/formatters/html_test.exs
@@ -117,15 +117,6 @@ defmodule Benchee.Formatters.HTMLTest do
     [comparison_html, job_html]
   end
 
-  test ".format includes the elixir and erlang version everywhere" do
-    {format, _} = HTML.format @sample_suite
-
-    Enum.each format, fn({_, html}) ->
-      assert html =~ "Elixir 1.4.0"
-      assert html =~ "Erlang 19.1"
-    end
-  end
-
   test ".format mentions the input" do
     {format, _} = HTML.format @sample_suite
 

--- a/test/benchee/formatters/html_test.exs
+++ b/test/benchee/formatters/html_test.exs
@@ -60,6 +60,20 @@ defmodule Benchee.Formatters.HTMLTest do
     end
   end
 
+  test ".format has system info in the html result" do
+    Enum.each comparison_and_job_htmls(), fn(html) ->
+      assert_includes html,
+        [
+          "Elixir: #{@system_info[:elixir]}",
+          "Erlang: #{@system_info[:erlang]}",
+          "Operating system: #{@system_info[:os]}",
+          "Available memory: #{@system_info[:available_memory]}",
+          "CPU Information: #{@system_info[:cpu_speed]}",
+          "Number of Available Cores: #{@system_info[:num_cores]}",
+        ]
+    end
+  end
+
   test ".format also scales the run times to ms" do
     statistics = %Benchee.Statistics{
       average:       1500.0,

--- a/test/benchee/formatters/html_test.exs
+++ b/test/benchee/formatters/html_test.exs
@@ -7,6 +7,14 @@ defmodule Benchee.Formatters.HTMLTest do
   @test_directory "test_output"
   @filename "#{@test_directory}/my.html"
   @expected_filename "#{@test_directory}/my_some_input_comparison.html"
+  @system_info %{
+    elixir: "1.4.0",
+    erlang: "19.1",
+    os: "macOS",
+    available_memory: "2 GB",
+    cpu_speed: "2.80GHz",
+    num_cores: 2
+  }
   @scenario %Benchee.Benchmark.Scenario{
     job_name: "My Job",
     run_times: [190, 200, 210],
@@ -26,7 +34,7 @@ defmodule Benchee.Formatters.HTMLTest do
   }
   @sample_suite %Benchee.Suite{
                    scenarios: [@scenario],
-                   system: %{elixir: "1.4.0", erlang: "19.1"},
+                   system: @system_info,
                    configuration: %Benchee.Configuration{
                      formatter_options: %{html: %{file: @filename}}
                    }
@@ -134,7 +142,7 @@ defmodule Benchee.Formatters.HTMLTest do
                    }
                  }
                ],
-               system: %{elixir: "1.4.0", erlang: "19.1"},
+               system: @system_info,
                configuration: %Benchee.Configuration{
                  formatter_options: %{html: %{file: @filename}}
                }


### PR DESCRIPTION
Pull request to #25 

@PragTob I've implemented system info in the report. It show info by default at the index page and allows to see it on other pages by clicking on version_note. See small gif:

![out](https://user-images.githubusercontent.com/114211/31861613-30b73932-b739-11e7-89fe-823dbabdd179.gif)

Let me know if you see some adjustments to be made
