### PR TITLE
Set Minimum Y Value on Raw Run Time Graphs to Reflect Actual Data Minimum

### DIFF
--- a/priv/assets/javascripts/benchee.js
+++ b/priv/assets/javascripts/benchee.js
@@ -23,7 +23,8 @@ var rawRunTimeData = function(runTimeData) {
   var data = [
     {
       y: runTimeData,
-      type: "bar"
+      type: "bar",
+      y0: 500
     }
   ];
 

--- a/priv/assets/javascripts/benchee.js
+++ b/priv/assets/javascripts/benchee.js
@@ -86,10 +86,10 @@ window.drawComparisonBoxPlot = function(runTimes, sortOrder, inputHeadline) {
   drawGraph(boxNode, boxPlotData(runTimes, sortOrder), layout);
 };
 
-window.drawRawRunTimeCharts = function(runTimes, statistics, inputHeadline) {
+window.drawRawRunTimeCharts = function(runTimes, inputHeadline, statistics) {
   var runTimeNode = document.getElementById("raw-run-times");
   var jobName = runTimeNode.getAttribute("data-job-name");
-  var minY = (statistics.minimum) - (0.1 * statistics.minimum);
+  var minY = statistics.minimum * 0.9;
   var maxY = statistics.maximum;
   var layout = {
     title: jobName + " Raw Run Times" + inputHeadline,

--- a/priv/assets/javascripts/benchee.js
+++ b/priv/assets/javascripts/benchee.js
@@ -94,7 +94,7 @@ window.drawRawRunTimeCharts = function(runTimes, statistics, inputHeadline) {
   var layout = {
     title: jobName + " Raw Run Times" + inputHeadline,
     yaxis: { title: RUN_TIME_AXIS_TITLE, range: [minY, maxY] },
-    xaxis: { title: "Sample number"},
+    xaxis: { title: "Sample number"}
   };
   drawGraph(runTimeNode, rawRunTimeData(runTimes), layout);
 };

--- a/priv/assets/javascripts/benchee.js
+++ b/priv/assets/javascripts/benchee.js
@@ -87,13 +87,15 @@ window.drawComparisonBoxPlot = function(runTimes, sortOrder, inputHeadline) {
   drawGraph(boxNode, boxPlotData(runTimes, sortOrder), layout);
 };
 
-window.drawRawRunTimeCharts = function(runTimes, inputHeadline) {
+window.drawRawRunTimeCharts = function(runTimes, statistics, inputHeadline) {
   var runTimeNode = document.getElementById("raw-run-times");
   var jobName = runTimeNode.getAttribute("data-job-name");
+  var minY = (statistics.minimum) - (0.1 * statistics.minimum);
+  var maxY = statistics.maximum;
   var layout = {
     title: jobName + " Raw Run Times" + inputHeadline,
-    yaxis: { title: RUN_TIME_AXIS_TITLE },
-    xaxis: { title: "Sample number"}
+    yaxis: { title: RUN_TIME_AXIS_TITLE, range: [minY, maxY] },
+    xaxis: { title: "Sample number"},
   };
   drawGraph(runTimeNode, rawRunTimeData(runTimes), layout);
 };

--- a/priv/assets/javascripts/benchee.js
+++ b/priv/assets/javascripts/benchee.js
@@ -23,8 +23,7 @@ var rawRunTimeData = function(runTimeData) {
   var data = [
     {
       y: runTimeData,
-      type: "bar",
-      y0: 500
+      type: "bar"
     }
   ];
 

--- a/priv/assets/javascripts/benchee.js
+++ b/priv/assets/javascripts/benchee.js
@@ -94,7 +94,8 @@ window.drawRawRunTimeCharts = function(runTimes, inputHeadline, statistics) {
   var layout = {
     title: jobName + " Raw Run Times" + inputHeadline,
     yaxis: { title: RUN_TIME_AXIS_TITLE, range: [minY, maxY] },
-    xaxis: { title: "Sample number"}
+    xaxis: { title: "Sample number"},
+    annotations: [{ x: 0, y: minY, text: parseInt(minY), showarrow: false, xref: "x", yref: "y", xshift: -10 }]
   };
   drawGraph(runTimeNode, rawRunTimeData(runTimes), layout);
 };

--- a/priv/templates/job_detail.html.eex
+++ b/priv/templates/job_detail.html.eex
@@ -36,10 +36,11 @@ Raw Run Times shows all individual recorded run times in the order they were rec
     <script>
       var measurements = <%= job_json %>;
       var runTimes     = measurements.run_times;
+      var statistics   = measurements.statistics;
 
       var inputHeadline = "<%= input_headline(input_name) %>"
 
-      drawRawRunTimeCharts(runTimes, inputHeadline);
+      drawRawRunTimeCharts(runTimes, inputHeadline, statistics);
       drawRunTimeHistograms(runTimes, inputHeadline);
     </script>
   </body>


### PR DESCRIPTION
See https://github.com/PragTob/benchee_html/issues/7

Hello @PragTob I have been looking through the plot.ly documentation and it appears that `y0` is meant to be as an alternative to `y` -- which accepts the array of run time data -- and thus will not fit this solution. The next best option I have found is a range layout setting. Implementing this setting to satisfy the requirements of this issue requires using it's minimum and maximum values and then applying the arithmetic in the original issue post to get a revised minimum value for the y axis. I have done this in my pull request in the javascript assets.